### PR TITLE
Fix misleading FIXME comments and enhance Tacotron multi-speaker tests

### DIFF
--- a/tests/tts_tests/test_tacotron_model.py
+++ b/tests/tts_tests/test_tacotron_model.py
@@ -53,7 +53,7 @@ class TacotronTrainTest(unittest.TestCase):
 
         criterion = L1LossMasked(seq_len_norm=False).to(device)
         criterion_st = nn.BCEWithLogitsLoss().to(device)
-        model = Tacotron(config).to(device)  # FIXME: missing num_speakers parameter to Tacotron ctor
+        model = Tacotron(config).to(device)
         model.train()
         print(" > Num parameters for Tacotron model:%s" % (count_parameters(model)))
         model_ref = copy.deepcopy(model)
@@ -107,7 +107,7 @@ class MultiSpeakeTacotronTrainTest(unittest.TestCase):
         criterion = L1LossMasked(seq_len_norm=False).to(device)
         criterion_st = nn.BCEWithLogitsLoss().to(device)
         config.d_vector_dim = 55
-        model = Tacotron(config).to(device)  # FIXME: missing num_speakers parameter to Tacotron ctor
+        model = Tacotron(config).to(device)
         model.train()
         print(" > Num parameters for Tacotron model:%s" % (count_parameters(model)))
         model_ref = copy.deepcopy(model)
@@ -166,7 +166,7 @@ class TacotronGSTTrainTest(unittest.TestCase):
         criterion_st = nn.BCEWithLogitsLoss().to(device)
         config.use_gst = True
         config.gst = GSTConfig()
-        model = Tacotron(config).to(device)  # FIXME: missing num_speakers parameter to Tacotron ctor
+        model = Tacotron(config).to(device)
         model.train()
         # print(model)
         print(" > Num parameters for Tacotron GST model:%s" % (count_parameters(model)))
@@ -218,7 +218,7 @@ class TacotronGSTTrainTest(unittest.TestCase):
 
         criterion = L1LossMasked(seq_len_norm=False).to(device)
         criterion_st = nn.BCEWithLogitsLoss().to(device)
-        model = Tacotron(config).to(device)  # FIXME: missing num_speakers parameter to Tacotron ctor
+        model = Tacotron(config).to(device)
         model.train()
         # print(model)
         print(" > Num parameters for Tacotron GST model:%s" % (count_parameters(model)))
@@ -344,7 +344,7 @@ class SCGSTMultiSpeakeTacotronTrainTest(unittest.TestCase):
         criterion = L1LossMasked(seq_len_norm=False).to(device)
         criterion_st = nn.BCEWithLogitsLoss().to(device)
         config.d_vector_dim = 55
-        model = Tacotron(config).to(device)  # FIXME: missing num_speakers parameter to Tacotron ctor
+        model = Tacotron(config).to(device)
         model.train()
         print(" > Num parameters for Tacotron model:%s" % (count_parameters(model)))
         model_ref = copy.deepcopy(model)
@@ -375,3 +375,144 @@ class SCGSTMultiSpeakeTacotronTrainTest(unittest.TestCase):
                 count, param.shape, param, param_ref
             )
             count += 1
+
+
+class MultiSpeakerFunctionalityTest(unittest.TestCase):
+    """Comprehensive tests for multi-speaker functionality in Tacotron model."""
+    
+    @staticmethod
+    def test_speaker_embedding_initialization():
+        """Test that speaker embeddings are correctly initialized for multi-speaker models."""
+        config = TacotronConfig(
+            num_chars=32,
+            num_speakers=8,
+            use_speaker_embedding=True,
+            out_channels=513,
+            decoder_output_dim=80
+        )
+        model = Tacotron(config).to(device)
+        
+        # Verify num_speakers is correctly set
+        assert model.num_speakers == 8, f"Expected num_speakers=8, got {model.num_speakers}"
+        
+        # Verify speaker embedding layer exists and has correct dimensions
+        assert hasattr(model, 'speaker_embedding'), "Model should have speaker_embedding attribute"
+        assert model.speaker_embedding is not None, "Speaker embedding should not be None"
+        assert model.speaker_embedding.num_embeddings == 8, \
+            f"Expected 8 speaker embeddings, got {model.speaker_embedding.num_embeddings}"
+        
+        print(" > Speaker embedding initialization test passed")
+    
+    @staticmethod
+    def test_single_vs_multi_speaker_models():
+        """Test differences between single-speaker and multi-speaker model configurations."""
+        # Single speaker configuration
+        config_single = TacotronConfig(
+            num_chars=32,
+            num_speakers=1,
+            use_speaker_embedding=False,
+            out_channels=513,
+            decoder_output_dim=80
+        )
+        model_single = Tacotron(config_single).to(device)
+        
+        # Multi-speaker configuration
+        config_multi = TacotronConfig(
+            num_chars=32,
+            num_speakers=5,
+            use_speaker_embedding=True,
+            out_channels=513,
+            decoder_output_dim=80
+        )
+        model_multi = Tacotron(config_multi).to(device)
+        
+        # Verify single speaker model doesn't have speaker embeddings
+        assert model_single.num_speakers == 1
+        assert model_single.speaker_embedding is None, \
+            "Single speaker model should not have speaker embeddings"
+        
+        # Verify multi-speaker model has speaker embeddings
+        assert model_multi.num_speakers == 5
+        assert model_multi.speaker_embedding is not None, \
+            "Multi-speaker model should have speaker embeddings"
+        assert model_multi.speaker_embedding.num_embeddings == 5
+        
+        # Verify decoder input dimensions are different
+        assert model_multi.decoder_in_features > model_single.decoder_in_features, \
+            "Multi-speaker model should have larger decoder input features"
+        
+        print(" > Single vs multi-speaker model test passed")
+    
+    @staticmethod
+    def test_speaker_id_forward_pass():
+        """Test forward pass with different speaker IDs."""
+        config = TacotronConfig(
+            num_chars=32,
+            num_speakers=5,
+            use_speaker_embedding=True,
+            out_channels=513,
+            decoder_output_dim=80
+        )
+        model = Tacotron(config).to(device)
+        model.eval()
+        
+        # Prepare inputs
+        batch_size = 4
+        text_input = torch.randint(0, 24, (batch_size, 50)).long().to(device)
+        text_lengths = torch.tensor([50, 45, 40, 35]).long().to(device)
+        mel_spec = torch.rand(batch_size, 30, config.audio["num_mels"]).to(device)
+        mel_lengths = torch.tensor([30, 28, 25, 22]).long().to(device)
+        
+        # Test with different speaker IDs
+        for speaker_id in range(5):
+            speaker_ids = torch.full((batch_size,), speaker_id, dtype=torch.long).to(device)
+            
+            with torch.no_grad():
+                outputs = model.forward(
+                    text_input, text_lengths, mel_spec, mel_lengths,
+                    aux_input={"speaker_ids": speaker_ids}
+                )
+            
+            assert "model_outputs" in outputs, f"Missing model_outputs for speaker {speaker_id}"
+            assert outputs["model_outputs"].shape[0] == batch_size
+            
+        print(" > Speaker ID forward pass test passed")
+    
+    @staticmethod  
+    def test_d_vector_configuration():
+        """Test Tacotron with d-vector based multi-speaker configuration."""
+        config = TacotronConfig(
+            num_chars=32,
+            num_speakers=10,
+            use_speaker_embedding=False,
+            use_d_vector_file=True,
+            d_vector_dim=256,
+            out_channels=513,
+            decoder_output_dim=80
+        )
+        model = Tacotron(config).to(device)
+        model.eval()
+        
+        # Verify configuration
+        assert model.num_speakers == 10
+        assert model.embedded_speaker_dim == 256
+        assert model.speaker_embedding is None, "Should not have speaker embeddings with d-vectors"
+        
+        # Test forward pass with d-vectors
+        batch_size = 2
+        text_input = torch.randint(0, 24, (batch_size, 30)).long().to(device)
+        text_lengths = torch.tensor([30, 25]).long().to(device)
+        mel_spec = torch.rand(batch_size, 20, config.audio["num_mels"]).to(device)
+        mel_lengths = torch.tensor([20, 18]).long().to(device)
+        d_vectors = torch.rand(batch_size, 256).to(device)
+        
+        with torch.no_grad():
+            outputs = model.forward(
+                text_input, text_lengths, mel_spec, mel_lengths,
+                aux_input={"d_vectors": d_vectors}
+            )
+        
+        assert "model_outputs" in outputs
+        assert outputs["model_outputs"].shape[0] == batch_size
+        
+        print(" > D-vector configuration test passed")


### PR DESCRIPTION
## Summary
- Removed 5 misleading FIXME comments about missing `num_speakers` parameter in Tacotron tests
- Added comprehensive test class `MultiSpeakerFunctionalityTest` with 4 new test methods
- Improved test coverage for multi-speaker functionality

## Background
The test file `tests/tts_tests/test_tacotron_model.py` contained FIXME comments at lines 56, 110, 169, 221, and 347 claiming the Tacotron constructor was missing a `num_speakers` parameter. After investigation, these comments were found to be incorrect.

## Investigation Findings
1. The Tacotron model constructor correctly takes a `config` object as its first parameter
2. The `config` object contains the `num_speakers` field
3. The model's `init_multispeaker` method (inherited from `BaseTTS`) properly sets `self.num_speakers` from the config
4. All existing tests were already correctly configured with appropriate `num_speakers` values

## Changes Made

### 1. Removed Misleading FIXME Comments
Removed 5 instances of:
```python
model = Tacotron(config).to(device)  # FIXME: missing num_speakers parameter to Tacotron ctor
```
Changed to:
```python
model = Tacotron(config).to(device)
```

### 2. Added Comprehensive Multi-Speaker Tests
Added new `MultiSpeakerFunctionalityTest` class with 4 test methods:

- **`test_speaker_embedding_initialization`**: Verifies that speaker embeddings are correctly initialized with the right number of speakers
- **`test_single_vs_multi_speaker_models`**: Tests the differences between single-speaker and multi-speaker model configurations, ensuring proper embedding initialization
- **`test_speaker_id_forward_pass`**: Tests forward pass with different speaker IDs to ensure multi-speaker functionality works correctly
- **`test_d_vector_configuration`**: Tests Tacotron with d-vector based multi-speaker configuration

## Test Plan
✅ Verified the Tacotron model constructor signature and initialization process
✅ Confirmed existing tests are properly configured
✅ Added 4 new comprehensive test methods for multi-speaker functionality
✅ Tests cover both speaker embedding and d-vector configurations
✅ Tests verify single-speaker backward compatibility

## Notes
- The original FIXME comments were misleading as the model already correctly handles `num_speakers` through the config object
- The new tests provide better coverage for multi-speaker scenarios
- All tests maintain backward compatibility with single-speaker models

🤖 Generated with [Claude Code](https://claude.ai/code)